### PR TITLE
Allows a user to generate a mappings file from their CosmosDB

### DIFF
--- a/CosmosToNeo4j/CosmosToNeo4j/CosmosToNeo4j.csproj
+++ b/CosmosToNeo4j/CosmosToNeo4j/CosmosToNeo4j.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="17.4.1" />
     <PackageReference Include="Neo4jClient" Version="5.1.3" />
   </ItemGroup>
 

--- a/CosmosToNeo4j/CosmosToNeo4j/FileHandler.cs
+++ b/CosmosToNeo4j/CosmosToNeo4j/FileHandler.cs
@@ -1,0 +1,27 @@
+﻿namespace CosmosToNeo4j;
+
+using CosmosToNeo4j.Models;
+using Newtonsoft.Json;
+
+public class FileHandler
+{
+    public static Mappings GenerateMappings(Stats stats)
+    {
+        var mappings = new Mappings
+        {
+            Nodes = GenerateMappings(stats.NodeLabelCounts.Keys),
+            Relationships = GenerateMappings(stats.RelationshipLabelCounts.Keys)
+        };
+        return mappings;
+    }
+
+    private static List<Map> GenerateMappings(IEnumerable<string> keys)
+    {
+        return keys.Select(k => new Map { Cosmos = k, Neo4j = k }).ToList();
+    }
+
+    public static async Task WriteMappingsFile(string path, Mappings mappings)
+    {
+        await File.WriteAllTextAsync(path, JsonConvert.SerializeObject(mappings));
+    }
+}

--- a/CosmosToNeo4j/CosmosToNeo4j/Models/Map.cs
+++ b/CosmosToNeo4j/CosmosToNeo4j/Models/Map.cs
@@ -1,8 +1,11 @@
 ﻿namespace CosmosToNeo4j.Models;
 
+using Newtonsoft.Json;
+
 public class Map
 {
     public string? Cosmos { get; set; }
     public string? Neo4j { get; set; }
+    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
     public List<PropertyMap>? Properties { get; set; }
 }

--- a/CosmosToNeo4j/CosmosToNeo4j/Properties/launchSettings.json
+++ b/CosmosToNeo4j/CosmosToNeo4j/Properties/launchSettings.json
@@ -15,6 +15,10 @@
     "Invalid Mapping": {
       "commandName": "Project",
       "commandLineArgs": "-mapping Mapping.LabelsNotThere.json -batchsize 100"
+    },
+    "GenerateMappings": {
+      "commandName": "Project",
+      "commandLineArgs": "-gm GeneratedMappings.json"
     }
   }
 }


### PR DESCRIPTION
Allows a user to supply a `-gm` or `-generatemappings` parameter to create a default mappings file for importing from CosmosDB

Usage:

```
CosmosToNeo4j.exe -gm generatedMappings.json
```